### PR TITLE
Add casts to `MEM_` macros

### DIFF
--- a/librecomp/include/librecomp/recomp.h
+++ b/librecomp/include/librecomp/recomp.h
@@ -18,23 +18,23 @@ typedef uint64_t gpr;
     ((gpr)(int32_t)((a) - (b)))
 
 #define MEM_W(offset, reg) \
-    (*(int32_t*)(rdram + ((((reg) + (offset))) - 0xFFFFFFFF80000000)))
+    (*(int32_t*)(rdram + ((((gpr)(reg) + (gpr)(offset))) - 0xFFFFFFFF80000000ULL)))
 
 #define MEM_H(offset, reg) \
-    (*(int16_t*)(rdram + ((((reg) + (offset)) ^ 2) - 0xFFFFFFFF80000000)))
+    (*(int16_t*)(rdram + ((((gpr)(reg) + (gpr)(offset)) ^ 2) - 0xFFFFFFFF80000000ULL)))
 
 #define MEM_B(offset, reg) \
-    (*(int8_t*)(rdram + ((((reg) + (offset)) ^ 3) - 0xFFFFFFFF80000000)))
+    (*(int8_t*)(rdram + ((((gpr)(reg) + (gpr)(offset)) ^ 3) - 0xFFFFFFFF80000000ULL)))
 
 #define MEM_HU(offset, reg) \
-    (*(uint16_t*)(rdram + ((((reg) + (offset)) ^ 2) - 0xFFFFFFFF80000000)))
+    (*(uint16_t*)(rdram + ((((gpr)(reg) + (gpr)(offset)) ^ 2) - 0xFFFFFFFF80000000ULL)))
 
 #define MEM_BU(offset, reg) \
-    (*(uint8_t*)(rdram + ((((reg) + (offset)) ^ 3) - 0xFFFFFFFF80000000)))
+    (*(uint8_t*)(rdram + ((((gpr)(reg) + (gpr)(offset)) ^ 3) - 0xFFFFFFFF80000000ULL)))
 
 #define SD(val, offset, reg) { \
-    *(uint32_t*)(rdram + ((((reg) + (offset) + 4)) - 0xFFFFFFFF80000000)) = (uint32_t)((gpr)(val) >> 0); \
-    *(uint32_t*)(rdram + ((((reg) + (offset) + 0)) - 0xFFFFFFFF80000000)) = (uint32_t)((gpr)(val) >> 32); \
+    *(uint32_t*)(rdram + ((((gpr)(reg) + (gpr)(offset) + 4)) - 0xFFFFFFFF80000000ULL)) = (uint32_t)((gpr)(val) >> 0); \
+    *(uint32_t*)(rdram + ((((gpr)(reg) + (gpr)(offset) + 0)) - 0xFFFFFFFF80000000ULL)) = (uint32_t)((gpr)(val) >> 32); \
 }
 
 static inline uint64_t load_doubleword(uint8_t* rdram, gpr reg, gpr offset) {

--- a/librecomp/src/pi.cpp
+++ b/librecomp/src/pi.cpp
@@ -153,14 +153,14 @@ void save_write_ptr(const void* in, uint32_t offset, uint32_t count) {
         std::lock_guard lock { save_context.save_buffer_mutex };
         memcpy(&save_context.save_buffer[offset], in, count);
     }
-    
+
     save_context.write_sempahore.signal();
 }
 
 void save_write(RDRAM_ARG PTR(void) rdram_address, uint32_t offset, uint32_t count) {
     {
         std::lock_guard lock { save_context.save_buffer_mutex };
-        for (uint32_t i = 0; i < count; i++) {
+        for (size_t i = 0; i < count; i++) {
             save_context.save_buffer[offset + i] = MEM_B(i, rdram_address);
         }
     }


### PR DESCRIPTION
Added `gpr` casts to the arguments of the `MEM_` macros to ensure the arithmetic is done as 64bits instead of something dumb because the caller passed 32bits unsigned values or similar. I also added `ULL` suffix to those big constants in the macro to ensure nothing will do something dumb.

I also changed `save_write` to use a `size_t` instead of `uint32_t` because that's the function that gave me problems in the first place

This PR was originally made in Zelda64Recomp/Zelda64Recomp#136
