### PR TITLE
Misc fixes

### DIFF
--- a/librecomp/src/overlays.cpp
+++ b/librecomp/src/overlays.cpp
@@ -143,9 +143,9 @@ extern "C" void unload_overlays(int32_t ram_addr, uint32_t size) {
 }
 
 void init_overlays() {
-    section_addresses = (int32_t *)malloc(sections_info.total_num_sections * sizeof(int32_t));
+    section_addresses = (int32_t *)malloc(sections_info.num_code_sections * sizeof(int32_t));
 
-    for (size_t section_index = 0; section_index < sections_info.total_num_sections; section_index++) {
+    for (size_t section_index = 0; section_index < sections_info.num_code_sections; section_index++) {
         section_addresses[sections_info.code_sections[section_index].index] = sections_info.code_sections[section_index].ram_addr;
     }
 

--- a/librecomp/src/overlays.cpp
+++ b/librecomp/src/overlays.cpp
@@ -143,7 +143,7 @@ extern "C" void unload_overlays(int32_t ram_addr, uint32_t size) {
 }
 
 void init_overlays() {
-    section_addresses = (int32_t *)malloc(sections_info.total_num_sections * sizeof(int32_t));
+    section_addresses = (int32_t *)calloc(sections_info.total_num_sections, sizeof(int32_t));
 
     for (size_t section_index = 0; section_index < sections_info.num_code_sections; section_index++) {
         section_addresses[sections_info.code_sections[section_index].index] = sections_info.code_sections[section_index].ram_addr;

--- a/librecomp/src/overlays.cpp
+++ b/librecomp/src/overlays.cpp
@@ -143,7 +143,7 @@ extern "C" void unload_overlays(int32_t ram_addr, uint32_t size) {
 }
 
 void init_overlays() {
-    section_addresses = (int32_t *)malloc(sections_info.num_code_sections * sizeof(int32_t));
+    section_addresses = (int32_t *)malloc(sections_info.total_num_sections * sizeof(int32_t));
 
     for (size_t section_index = 0; section_index < sections_info.num_code_sections; section_index++) {
         section_addresses[sections_info.code_sections[section_index].index] = sections_info.code_sections[section_index].ram_addr;

--- a/librecomp/src/patch_loading.cpp
+++ b/librecomp/src/patch_loading.cpp
@@ -4,6 +4,7 @@
 #include "recomp.h"
 #include "sections.h"
 #include "overlays.hpp"
+#include "ultramodern/ultramodern.hpp"
 
 static SectionTableEntry* code_sections = nullptr;
 
@@ -14,5 +15,9 @@ void recomp::register_patch_section(SectionTableEntry* sections) {
 }
 
 void recomp::load_patch_functions() {
+    if (code_sections == nullptr) {
+        debug_printf("[Patch] No patch section was registered\n");
+        return;
+    }
     load_special_overlay(code_sections[0], code_sections[0].ram_addr);
 }

--- a/ultramodern/include/ultramodern/ultramodern.hpp
+++ b/ultramodern/include/ultramodern/ultramodern.hpp
@@ -183,7 +183,7 @@ void set_callbacks(const rsp::callbacks_t& rsp_callbacks, const audio_callbacks_
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 
-#define debug_printf(...)
-//#define debug_printf(...) printf(__VA_ARGS__);
+// #define debug_printf(...)
+#define debug_printf(...) printf(__VA_ARGS__);
 
 #endif

--- a/ultramodern/include/ultramodern/ultramodern.hpp
+++ b/ultramodern/include/ultramodern/ultramodern.hpp
@@ -183,7 +183,7 @@ void set_callbacks(const rsp::callbacks_t& rsp_callbacks, const audio_callbacks_
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 
-// #define debug_printf(...)
-#define debug_printf(...) printf(__VA_ARGS__);
+#define debug_printf(...)
+//#define debug_printf(...) printf(__VA_ARGS__);
 
 #endif


### PR DESCRIPTION
- Allows to not register any patch section. Currently we were blindly assuming patches were always being registered.
- Fix OoB access when registering overlays.