### PR TITLE
Use non git@ submodule url for xxHash

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "thirdparty/xxHash"]
 	path = thirdparty/xxHash
-	url = git@github.com:Cyan4973/xxHash.git
+	url = https://github.com/Cyan4973/xxHash.git


### PR DESCRIPTION
This results in the submodule not working for some if they don't have an ssh key set up.