### PR TITLE
Add custom save type

### DIFF
--- a/librecomp/include/librecomp/game.hpp
+++ b/librecomp/include/librecomp/game.hpp
@@ -16,6 +16,7 @@ namespace recomp {
         Sram,
         Flashram,
         AllowAll, // Allows all save types to work and reports eeprom size as 16kbit.
+        Custom, // Custom save type for recomp with a configurable size.
     };
 
     struct GameEntry {
@@ -25,6 +26,7 @@ namespace recomp {
         std::string mod_game_id;
         std::span<const char> cache_data;
         SaveType save_type = SaveType::None;
+        uint32_t custom_save_size = 0;
         bool is_enabled;
 
         gpr entrypoint_address;
@@ -99,6 +101,7 @@ namespace recomp {
     bool eeprom_allowed();
     bool sram_allowed();
     bool flashram_allowed();
+    bool custom_saving_allowed();
 
     void start_game(const std::u8string& game_id);
     std::u8string current_game_id();

--- a/librecomp/src/recomp.cpp
+++ b/librecomp/src/recomp.cpp
@@ -550,7 +550,7 @@ bool wait_for_game_started(uint8_t* rdram, recomp_context* context) {
                 recomp::init_heap(rdram, recomp::mod_rdram_start + mod_ram_used);
 
                 save_type = game_entry.save_type;
-                ultramodern::init_saving(rdram);
+                ultramodern::init_saving(rdram, game_entry.custom_save_size);
 
                 try {
                     game_entry.entrypoint(rdram, context);
@@ -588,6 +588,12 @@ bool recomp::sram_allowed() {
 bool recomp::flashram_allowed() {
     return
         save_type == SaveType::Flashram || 
+        save_type == SaveType::AllowAll;
+}
+
+bool recomp::custom_saving_allowed() {
+    return
+        save_type == SaveType::Custom || 
         save_type == SaveType::AllowAll;
 }
 

--- a/ultramodern/include/ultramodern/ultramodern.hpp
+++ b/ultramodern/include/ultramodern/ultramodern.hpp
@@ -31,7 +31,7 @@ constexpr uint32_t save_size = 1024 * 1024 / 8; // Maximum save size, 1Mbit for 
 
 // Initialization.
 void preinit(RDRAM_ARG renderer::WindowHandle window_handle);
-void init_saving(RDRAM_ARG1);
+void init_saving(RDRAM_ARG uint32_t custom_save_size);
 void init_events(RDRAM_ARG renderer::WindowHandle window_handle);
 void init_timers(RDRAM_ARG1);
 void init_thread_cleanup();


### PR DESCRIPTION
This save type has a very simple interface with two functions (shown from the perspective of recompiled code):
* `void recomp_save_write(void* rdram_address, u32 offset, u32 count);`
* `void recomp_save_read(void* rdram_address, u32 offset, u32 count);`
It can be used when the save type is `Custom` or `AllowAll` and has a configurable size that's set in the `GameEntry`.