### PR TITLE
Mod function hooking

### DIFF
--- a/librecomp/CMakeLists.txt
+++ b/librecomp/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(librecomp STATIC
     "${CMAKE_CURRENT_SOURCE_DIR}/src/math_routines.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/mods.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_events.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_hooks.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_manifest.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/overlays.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/pak.cpp"

--- a/librecomp/include/librecomp/game.hpp
+++ b/librecomp/include/librecomp/game.hpp
@@ -23,9 +23,11 @@ namespace recomp {
         std::string internal_name;
         std::u8string game_id;
         std::string mod_game_id;
-        std::span<const char> cache_data;
         SaveType save_type = SaveType::None;
         bool is_enabled;
+        // Only needed for mod function hooking support, not needed if `has_compressed_code` is false.
+        std::vector<uint8_t> (*decompression_routine)(std::span<const uint8_t> compressed_rom) = nullptr;
+        bool has_compressed_code = false;
 
         gpr entrypoint_address;
         void (*entrypoint)(uint8_t* rdram, recomp_context* context);
@@ -73,6 +75,7 @@ namespace recomp {
     bool is_rom_valid(std::u8string& game_id);
     bool is_rom_loaded();
     void set_rom_contents(std::vector<uint8_t>&& new_rom);
+    std::span<const uint8_t> get_rom();
     void do_rom_read(uint8_t* rdram, gpr ram_address, uint32_t physical_addr, size_t num_bytes);
     void do_rom_pio(uint8_t* rdram, gpr ram_address, uint32_t physical_addr);
     const Version& get_project_version();

--- a/librecomp/include/librecomp/mods.hpp
+++ b/librecomp/include/librecomp/mods.hpp
@@ -78,7 +78,7 @@ namespace recomp {
             InvalidCallbackEvent,
             InvalidFunctionReplacement,
             FailedToFindReplacement,
-            ReplacementConflict,
+            BaseRecompConflict,
             ModConflict,
             DuplicateExport,
             NoSpecifiedApiVersion,
@@ -220,7 +220,7 @@ namespace recomp {
             void enable_mod(const std::string& mod_id, bool enabled);
             bool is_mod_enabled(const std::string& mod_id);
             size_t num_opened_mods();
-            std::vector<ModLoadErrorDetails> load_mods(const std::string& mod_game_id, uint8_t* rdram, int32_t load_address, uint32_t& ram_used);
+            std::vector<ModLoadErrorDetails> load_mods(const GameEntry& game_entry, uint8_t* rdram, int32_t load_address, uint32_t& ram_used);
             void unload_mods();
             std::vector<ModDetails> get_mod_details(const std::string& mod_game_id);
             ModContentTypeId register_content_type(const ModContentType& type);
@@ -232,7 +232,7 @@ namespace recomp {
             ModLoadError load_mod(recomp::mods::ModHandle& mod, std::string& error_param);
             void check_dependencies(recomp::mods::ModHandle& mod, std::vector<std::pair<recomp::mods::ModLoadError, std::string>>& errors);
             CodeModLoadError load_mod_code(uint8_t* rdram, const std::unordered_map<uint32_t, uint16_t>& section_vrom_map, recomp::mods::ModHandle& mod, int32_t load_address, uint32_t& ram_used, std::string& error_param);
-            CodeModLoadError resolve_code_dependencies(recomp::mods::ModHandle& mod, std::string& error_param);
+            CodeModLoadError resolve_code_dependencies(recomp::mods::ModHandle& mod, const std::unordered_set<recomp_func_t*> base_patched_funcs, std::string& error_param);
             void add_opened_mod(ModManifest&& manifest, std::vector<size_t>&& game_indices, std::vector<ModContentTypeId>&& detected_content_types);
             void close_mods();
 

--- a/librecomp/include/librecomp/mods.hpp
+++ b/librecomp/include/librecomp/mods.hpp
@@ -22,6 +22,7 @@
 #include "recomp.h"
 #include "librecomp/game.hpp"
 #include "librecomp/sections.h"
+#include "librecomp/overlays.hpp"
 
 namespace N64Recomp {
     class Context;
@@ -262,9 +263,14 @@ namespace recomp {
             void check_dependencies(ModHandle& mod, std::vector<std::pair<ModLoadError, std::string>>& errors);
             CodeModLoadError init_mod_code(uint8_t* rdram, const std::unordered_map<uint32_t, uint16_t>& section_vrom_map, ModHandle& mod, int32_t load_address, bool hooks_available, uint32_t& ram_used, std::string& error_param);
             CodeModLoadError load_mod_code(uint8_t* rdram, ModHandle& mod, uint32_t base_event_index, std::string& error_param);
-            CodeModLoadError resolve_code_dependencies(ModHandle& mod, const std::unordered_set<recomp_func_t*> base_patched_funcs, std::string& error_param);
+            CodeModLoadError resolve_code_dependencies(ModHandle& mod, const std::unordered_map<recomp_func_t*, recomp::overlays::BasePatchedFunction>& base_patched_funcs, std::string& error_param);
             void add_opened_mod(ModManifest&& manifest, std::vector<size_t>&& game_indices, std::vector<ModContentTypeId>&& detected_content_types);
             void close_mods();
+            std::vector<ModLoadErrorDetails> regenerate_with_hooks(
+                const std::vector<std::pair<HookDefinition, size_t>>& sorted_unprocessed_hooks,
+                const std::unordered_map<uint32_t, uint16_t>& section_vrom_map,
+                const std::unordered_map<recomp_func_t*, overlays::BasePatchedFunction>& base_patched_funcs,
+                std::span<const uint8_t> decompressed_rom);
 
             static void on_code_mod_enabled(ModContext& context, const ModHandle& mod);
 
@@ -281,6 +287,8 @@ namespace recomp {
             std::vector<size_t> loaded_code_mods;
             // Code handle for vanilla code that was regenerated to add hooks.
             std::unique_ptr<LiveRecompilerCodeHandle> regenerated_code_handle;
+            // Code handle for base patched code that was regenerated to add hooks.
+            std::unique_ptr<LiveRecompilerCodeHandle> base_patched_code_handle;
             // Map of hook definition to the entry hook slot's index.
             std::unordered_map<HookDefinition, size_t> hook_slots;
             // Tracks which hook slots have already been processed. Used to regenerate vanilla functions as needed

--- a/librecomp/include/librecomp/overlays.hpp
+++ b/librecomp/include/librecomp/overlays.hpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include "sections.h"
 
 namespace recomp {
@@ -37,6 +38,8 @@ namespace recomp {
         size_t num_base_events();
 
         void add_loaded_function(int32_t ram_addr, recomp_func_t* func);
+
+        std::unordered_set<recomp_func_t*> get_base_patched_funcs();
     }
 };
 

--- a/librecomp/include/librecomp/overlays.hpp
+++ b/librecomp/include/librecomp/overlays.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <span>
 #include "sections.h"
 
 namespace recomp {
@@ -42,6 +43,9 @@ namespace recomp {
         void add_loaded_function(int32_t ram_addr, recomp_func_t* func);
 
         std::unordered_set<recomp_func_t*> get_base_patched_funcs();
+
+        std::span<const RelocEntry> get_section_relocs(uint16_t code_section_index);
+        std::span<const RelocEntry> get_patch_section_relocs(uint16_t patch_code_section_index);
     }
 };
 

--- a/librecomp/include/librecomp/overlays.hpp
+++ b/librecomp/include/librecomp/overlays.hpp
@@ -5,7 +5,6 @@
 #include <cstddef>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 #include <span>
 #include "sections.h"
 
@@ -28,11 +27,13 @@ namespace recomp {
         void register_base_export(const std::string& name, recomp_func_t* func);
         void register_base_exports(const FunctionExport* exports);
         void register_base_events(char const* const* event_names);
+        void register_manual_patch_symbols(const ManualPatchSymbol* manual_patch_symbols);
         void read_patch_data(uint8_t* rdram, gpr patch_data_address);
 
         void init_overlays();
         const std::unordered_map<uint32_t, uint16_t>& get_vrom_to_section_map();
         uint32_t get_section_ram_addr(uint16_t code_section_index);
+        std::span<const RelocEntry> get_section_relocs(uint16_t code_section_index);
         recomp_func_t* get_func_by_section_rom_function_vram(uint32_t section_rom, uint32_t function_vram);
         bool get_func_entry_by_section_index_function_offset(uint16_t code_section_index, uint32_t function_offset, FuncEntry& func_out);
         recomp_func_t* get_func_by_section_index_function_offset(uint16_t code_section_index, uint32_t function_offset);
@@ -42,10 +43,19 @@ namespace recomp {
 
         void add_loaded_function(int32_t ram_addr, recomp_func_t* func);
 
-        std::unordered_set<recomp_func_t*> get_base_patched_funcs();
+        struct BasePatchedFunction {
+            size_t patch_section;
+            size_t function_index;
+        };
 
-        std::span<const RelocEntry> get_section_relocs(uint16_t code_section_index);
+        std::unordered_map<recomp_func_t*, BasePatchedFunction> get_base_patched_funcs();
+        const std::unordered_map<uint32_t, uint16_t>& get_patch_vrom_to_section_map();
+        uint32_t get_patch_section_ram_addr(uint16_t patch_code_section_index);
+        uint32_t get_patch_section_rom_addr(uint16_t patch_code_section_index);
+        const FuncEntry* get_patch_function_entry(uint16_t patch_code_section_index, size_t function_index);
+        bool get_patch_func_entry_by_section_index_function_offset(uint16_t code_section_index, uint32_t function_offset, FuncEntry& func_out);
         std::span<const RelocEntry> get_patch_section_relocs(uint16_t patch_code_section_index);
+        std::span<const uint8_t> get_patch_binary();
     }
 };
 

--- a/librecomp/include/librecomp/overlays.hpp
+++ b/librecomp/include/librecomp/overlays.hpp
@@ -31,7 +31,9 @@ namespace recomp {
 
         void init_overlays();
         const std::unordered_map<uint32_t, uint16_t>& get_vrom_to_section_map();
+        uint32_t get_section_ram_addr(uint16_t code_section_index);
         recomp_func_t* get_func_by_section_rom_function_vram(uint32_t section_rom, uint32_t function_vram);
+        bool get_func_entry_by_section_index_function_offset(uint16_t code_section_index, uint32_t function_offset, FuncEntry& func_out);
         recomp_func_t* get_func_by_section_index_function_offset(uint16_t code_section_index, uint32_t function_offset);
         recomp_func_t* get_base_export(const std::string& export_name);
         size_t get_base_event_index(const std::string& event_name);

--- a/librecomp/include/librecomp/sections.h
+++ b/librecomp/include/librecomp/sections.h
@@ -9,6 +9,7 @@
 typedef struct {
     recomp_func_t* func;
     uint32_t offset;
+    uint32_t rom_size;
 } FuncEntry;
 
 typedef struct {

--- a/librecomp/include/librecomp/sections.h
+++ b/librecomp/include/librecomp/sections.h
@@ -12,12 +12,36 @@ typedef struct {
     uint32_t rom_size;
 } FuncEntry;
 
+typedef enum {
+    R_MIPS_NONE = 0,
+    R_MIPS_16,
+    R_MIPS_32,
+    R_MIPS_REL32,
+    R_MIPS_26,
+    R_MIPS_HI16,
+    R_MIPS_LO16,
+    R_MIPS_GPREL16,
+} RelocEntryType;
+
+typedef struct {
+    // Offset into the section of the word to relocate.
+    uint32_t offset;
+    // Reloc addend from the target section's address.
+    uint32_t target_section_offset;
+    // Index of the target section (indexes into `section_addresses`).
+    uint16_t target_section;
+    // Relocation type.
+    RelocEntryType type;
+} RelocEntry;
+
 typedef struct {
     uint32_t rom_addr;
     uint32_t ram_addr;
     uint32_t size;
     FuncEntry *funcs;
     size_t num_funcs;
+    RelocEntry* relocs;
+    size_t num_relocs;
     size_t index;
 } SectionTableEntry;
 

--- a/librecomp/include/librecomp/sections.h
+++ b/librecomp/include/librecomp/sections.h
@@ -50,4 +50,9 @@ typedef struct {
     uint32_t ram_addr;
 } FunctionExport;
 
+typedef struct {
+    uint32_t ram_addr;
+    recomp_func_t* func;
+} ManualPatchSymbol;
+
 #endif

--- a/librecomp/src/mod_hooks.cpp
+++ b/librecomp/src/mod_hooks.cpp
@@ -1,0 +1,51 @@
+#include <vector>
+#include "librecomp/mods.hpp"
+#include "librecomp/overlays.hpp"
+#include "ultramodern/error_handling.hpp"
+
+template<class... Ts>
+struct overloaded : Ts... { using Ts::operator()...; };
+template<class... Ts>
+overloaded(Ts...) -> overloaded<Ts...>;
+
+// Vector of individual hooks for each hook slot.
+std::vector<std::vector<recomp::mods::GenericFunction>> hook_table{};
+
+void recomp::mods::run_hook(uint8_t* rdram, recomp_context* ctx, size_t hook_slot_index) {
+    // Sanity check the hook slot index.
+    if (hook_slot_index >= hook_table.size()) {
+        printf("Hook slot %zu triggered, but only %zu hook slots have been registered!\n", hook_slot_index, hook_table.size());
+        assert(false);
+        ultramodern::error_handling::message_box("Encountered an error with loaded mods: hook slot out of bounds");
+        ULTRAMODERN_QUICK_EXIT();
+    }
+
+    // Copy the initial context state to restore it after running each callback.
+    recomp_context initial_context = *ctx;
+
+    // Call every hook attached to the hook slot.
+    const std::vector<recomp::mods::GenericFunction>& hooks = hook_table[hook_slot_index];
+    for (recomp::mods::GenericFunction func : hooks) {
+        // Run the hook.
+        std::visit(overloaded {
+            [rdram, ctx](recomp_func_t* native_func) {
+                native_func(rdram, ctx);
+            },
+        }, func);
+
+        // Restore the original context.
+        *ctx = initial_context;
+    }
+}
+
+void recomp::mods::setup_hooks(size_t num_hook_slots) {
+    hook_table.resize(num_hook_slots);
+}
+
+void recomp::mods::register_hook(size_t hook_slot_index, GenericFunction callback) {
+    hook_table[hook_slot_index].emplace_back(callback);
+}
+
+void recomp::mods::reset_hooks() {
+    hook_table.clear();
+}

--- a/librecomp/src/mod_manifest.cpp
+++ b/librecomp/src/mod_manifest.cpp
@@ -589,6 +589,8 @@ std::string recomp::mods::error_to_string(CodeModLoadError error) {
             return "Conflicts with other mod";
         case CodeModLoadError::DuplicateExport:
             return "Duplicate exports in mod";
+        case CodeModLoadError::OfflineModHooked:
+            return "Offline recompiled mod has a function hooked by another mod";
         case CodeModLoadError::NoSpecifiedApiVersion:
             return "Mod DLL does not specify an API version";
         case CodeModLoadError::UnsupportedApiVersion:

--- a/librecomp/src/mod_manifest.cpp
+++ b/librecomp/src/mod_manifest.cpp
@@ -583,8 +583,8 @@ std::string recomp::mods::error_to_string(CodeModLoadError error) {
             return "Function to be replaced does not exist";
         case CodeModLoadError::FailedToFindReplacement:
             return "Failed to find replacement function";
-        case CodeModLoadError::ReplacementConflict:
-            return "Attempted to replace a function that cannot be replaced";
+        case CodeModLoadError::BaseRecompConflict:
+            return "Attempted to replace a function that's been patched by the base recomp";
         case CodeModLoadError::ModConflict:
             return "Conflicts with other mod";
         case CodeModLoadError::DuplicateExport:

--- a/librecomp/src/mod_manifest.cpp
+++ b/librecomp/src/mod_manifest.cpp
@@ -581,6 +581,14 @@ std::string recomp::mods::error_to_string(CodeModLoadError error) {
             return "Event for callback not found";
         case CodeModLoadError::InvalidFunctionReplacement:
             return "Function to be replaced does not exist";
+        case CodeModLoadError::HooksUnavailable:
+            // This error will occur if the ROM's GameEntry is set as having compressed code, but no
+            // ROM decompression routine has been provided. 
+            return "Function hooks are currently unavailable in this project";
+        case CodeModLoadError::InvalidHook:
+            return "Function to be hooked does not exist";
+        case CodeModLoadError::CannotBeHooked:
+            return "Function is not hookable";
         case CodeModLoadError::FailedToFindReplacement:
             return "Failed to find replacement function";
         case CodeModLoadError::BaseRecompConflict:

--- a/librecomp/src/mods.cpp
+++ b/librecomp/src/mods.cpp
@@ -963,6 +963,7 @@ std::vector<recomp::mods::ModLoadErrorDetails> recomp::mods::ModContext::load_mo
         uint32_t cur_ram_used = 0;
         auto& mod = opened_mods[mod_index];
         std::string cur_error_param;
+        size_t base_event_index = num_events;
         CodeModLoadError cur_error = init_mod_code(rdram, section_vrom_map, mod, load_address, !decompressed_rom.empty(), cur_ram_used, cur_error_param);
         if (cur_error != CodeModLoadError::Good) {
             if (cur_error_param.empty()) {
@@ -975,7 +976,7 @@ std::vector<recomp::mods::ModLoadErrorDetails> recomp::mods::ModContext::load_mo
         else {
             load_address += cur_ram_used;
             ram_used += cur_ram_used;
-            base_event_indices[mod_index] = static_cast<uint32_t>(num_events);
+            base_event_indices[mod_index] = static_cast<uint32_t>(base_event_index);
         }
     }
 

--- a/librecomp/src/overlays.cpp
+++ b/librecomp/src/overlays.cpp
@@ -344,3 +344,21 @@ std::unordered_set<recomp_func_t*> recomp::overlays::get_base_patched_funcs() {
 
     return ret;
 }
+
+std::span<const RelocEntry> recomp::overlays::get_section_relocs(uint16_t code_section_index) {
+    if (code_section_index < sections_info.num_code_sections) {
+        const auto& section = sections_info.code_sections[code_section_index];
+        return std::span{ section.relocs, section.num_relocs };
+    }
+    assert(false);
+    return {};
+}
+
+std::span<const RelocEntry> recomp::overlays::get_patch_section_relocs(uint16_t patch_code_section_index) {
+    if (patch_code_section_index < num_patch_code_sections) {
+        const auto& section = patch_code_sections[patch_code_section_index];
+        return std::span{ section.relocs, section.num_relocs };
+    }
+    assert(false);
+    return {};
+}

--- a/librecomp/src/pi.cpp
+++ b/librecomp/src/pi.cpp
@@ -21,6 +21,10 @@ void recomp::set_rom_contents(std::vector<uint8_t>&& new_rom) {
     rom = std::move(new_rom);
 }
 
+std::span<const uint8_t> recomp::get_rom() {
+    return rom;
+}
+
 constexpr uint32_t k1_to_phys(uint32_t addr) {
     return addr & 0x1FFFFFFF;
 }

--- a/librecomp/src/recomp.cpp
+++ b/librecomp/src/recomp.cpp
@@ -536,7 +536,7 @@ bool wait_for_game_started(uint8_t* rdram, recomp_context* context) {
                     std::vector<recomp::mods::ModLoadErrorDetails> mod_load_errors;
                     {
                         std::lock_guard lock { mod_context_mutex };
-                        mod_load_errors = mod_context->load_mods(game_entry.mod_game_id, rdram, recomp::mod_rdram_start, mod_ram_used);
+                        mod_load_errors = mod_context->load_mods(game_entry, rdram, recomp::mod_rdram_start, mod_ram_used);
                     }
 
                     if (!mod_load_errors.empty()) {

--- a/librecomp/src/recomp.cpp
+++ b/librecomp/src/recomp.cpp
@@ -460,13 +460,13 @@ void init(uint8_t* rdram, recomp_context* ctx, gpr entrypoint) {
 
     // Initialize variables normally set by IPL3
     constexpr int32_t osTvType = 0x80000300;
-    constexpr int32_t osRomType = 0x80000304;
+    //constexpr int32_t osRomType = 0x80000304;
     constexpr int32_t osRomBase = 0x80000308;
     constexpr int32_t osResetType = 0x8000030c;
-    constexpr int32_t osCicId = 0x80000310;
-    constexpr int32_t osVersion = 0x80000314;
+    //constexpr int32_t osCicId = 0x80000310;
+    //constexpr int32_t osVersion = 0x80000314;
     constexpr int32_t osMemSize = 0x80000318;
-    constexpr int32_t osAppNMIBuffer = 0x8000031c;
+    //constexpr int32_t osAppNMIBuffer = 0x8000031c;
     MEM_W(osTvType, 0) = 1; // NTSC
     MEM_W(osRomBase, 0) = 0xB0000000u; // standard rom base
     MEM_W(osResetType, 0) = 0; // cold reset

--- a/ultramodern/include/ultramodern/renderer_context.hpp
+++ b/ultramodern/include/ultramodern/renderer_context.hpp
@@ -90,7 +90,7 @@ namespace ultramodern {
             /**
              * This callback is optional. If not provided a library default will be used.
              */
-            get_graphics_api_name_t *get_graphics_api_name;
+            get_graphics_api_name_t *get_graphics_api_name = nullptr;
         };
 
         void set_callbacks(const callbacks_t& callbacks);


### PR DESCRIPTION
Implements a mechanism for mods to hook the entry point and return point(s) of any function. This includes functions that are still vanilla, functions that have been replaced by other mods, and functions that have been patched by the base recomp project.