### PR TITLE
Rename manifest to mod.json and add new manifest fields, rework config parsing to allow unknown manifest fields

### DIFF
--- a/librecomp/include/librecomp/mods.hpp
+++ b/librecomp/include/librecomp/mods.hpp
@@ -64,7 +64,6 @@ namespace recomp {
             NoManifest,
             FailedToParseManifest,
             InvalidManifestSchema,
-            UnrecognizedManifestField,
             IncorrectManifestFieldType,
             InvalidVersionString,
             InvalidMinimumRecompVersionString,
@@ -157,6 +156,9 @@ namespace recomp {
 
         struct ModDetails {
             std::string mod_id;
+            std::string display_name;
+            std::string description;
+            std::string short_description;
             Version version;
             std::vector<std::string> authors;
             std::vector<Dependency> dependencies;
@@ -168,6 +170,9 @@ namespace recomp {
 
             std::vector<std::string> mod_game_ids;
             std::string mod_id;
+            std::string display_name;
+            std::string description;
+            std::string short_description;
             std::vector<std::string> authors;
             std::vector<Dependency> dependencies;
             std::unordered_map<std::string, size_t> dependencies_by_id;

--- a/librecomp/src/mods.cpp
+++ b/librecomp/src/mods.cpp
@@ -742,6 +742,9 @@ std::vector<recomp::mods::ModDetails> recomp::mods::ModContext::get_mod_details(
 
             ret.emplace_back(ModDetails{
                 .mod_id = mod.manifest.mod_id,
+                .display_name = mod.manifest.display_name,
+                .description = mod.manifest.description,
+                .short_description = mod.manifest.short_description,
                 .version = mod.manifest.version,
                 .authors = mod.manifest.authors,
                 .dependencies = mod.manifest.dependencies,


### PR DESCRIPTION
This PR adds the "display_name" (required), "description" (optional), and "short_description" (optional) fields to the manifest. This PR also allows unrecognized fields in the mod manifest (which get ignored) to allow for interop with RT64 texture pack manifest fields in the future.