### PR TITLE
Move dummy VI origin beyond any known game's load address

### DIFF
--- a/ultramodern/src/events.cpp
+++ b/ultramodern/src/events.cpp
@@ -160,7 +160,7 @@ void vi_thread_func() {
                 else {
                     set_dummy_vi();
                     static bool swap = false;
-                    uint32_t vi_origin = 0x400 + 0x280; // Skip initial RDRAM contents and add the usual origin offset
+                    uint32_t vi_origin = 0x80700000; // Skip initial RDRAM contents
                     // Offset by one FB every other frame so RT64 continues drawing
                     if (swap) {
                         vi_origin += 0x25800;


### PR DESCRIPTION
This is necessary for at least Dinosaur Planet which has a load address of `0x80000400`. Currently during ubershader compilation, garbage framebuffer values will be displayed in Dino Planet since the current dummy VI overlaps the game's boot code.

Tested to the best of my ability that this does not break anything in the Majora recomp.