### PR TITLE
Implement osPfsInit and osPfsIsPlug functions with error handling

### DIFF
--- a/librecomp/src/mod_manifest.cpp
+++ b/librecomp/src/mod_manifest.cpp
@@ -1032,4 +1032,6 @@ std::string recomp::mods::error_to_string(CodeModLoadError error) {
         case CodeModLoadError::UnsupportedApiVersion:
             return "Mod DLL has an unsupported API version";
     }
+
+    return "Unknown code mod load error";
 }

--- a/librecomp/src/pak.cpp
+++ b/librecomp/src/pak.cpp
@@ -8,6 +8,16 @@ extern "C" void osPfsInitPak_recomp(uint8_t * rdram, recomp_context* ctx) {
     ctx->r2 = 1; // PFS_ERR_NOPACK
 }
 
+extern "C" void osPfsInit_recomp(uint8_t * rdram, recomp_context * ctx) {
+    ctx->r2 = 1; // PFS_ERR_NOPACK
+}
+
+extern "C" void osPfsIsPlug_recomp(uint8_t * rdram, recomp_context * ctx) {
+    u8* pattern = _arg<1, u8*>(rdram, ctx);
+    *pattern = 0; // No controller pak plugged in
+    ctx->r2 = 0;
+}
+
 extern "C" void osPfsFreeBlocks_recomp(uint8_t * rdram, recomp_context * ctx) {
     ctx->r2 = 1; // PFS_ERR_NOPACK
 }

--- a/librecomp/src/recomp.cpp
+++ b/librecomp/src/recomp.cpp
@@ -704,6 +704,8 @@ bool wait_for_game_started(uint8_t* rdram, recomp_context* context) {
         case GameStatus::None:
             return true;
     }
+
+    return true;
 }
 
 recomp::SaveType recomp::get_save_type() {


### PR DESCRIPTION
This pull request adds new stub implementations for PFS (Controller Pak) related functions in the `librecomp/src/pak.cpp` file. These stubs help simulate the absence of a controller pak and ensure that related calls do not cause errors. This resolves call dependencies of osPfs* and forces the path expected by the game when there is no memcard, preventing integration failures and maintaining stable and predictable behavior.

New PFS stub functions:

* Added `osPfsInit_recomp`, which sets the return code to indicate no controller pak is present.
* Added `osPfsIsPlug_recomp`, which sets the output pattern to 0 (no pak plugged in) and the return code to success.