### PR TITLE
Live recompiler support for PIC jump tables

### DIFF
--- a/librecomp/include/librecomp/overlays.hpp
+++ b/librecomp/include/librecomp/overlays.hpp
@@ -34,6 +34,7 @@ namespace recomp {
         void init_overlays();
         const std::unordered_map<uint32_t, uint16_t>& get_vrom_to_section_map();
         uint32_t get_section_ram_addr(uint16_t code_section_index);
+        std::optional<uint32_t> get_section_got_ram_addr(uint16_t code_section_index);
         std::span<const RelocEntry> get_section_relocs(uint16_t code_section_index);
         recomp_func_t* get_func_by_section_rom_function_vram(uint32_t section_rom, uint32_t function_vram);
         bool get_func_entry_by_section_index_function_offset(uint16_t code_section_index, uint32_t function_offset, FuncEntry& func_out);

--- a/librecomp/include/librecomp/sections.h
+++ b/librecomp/include/librecomp/sections.h
@@ -1,6 +1,7 @@
 #ifndef __SECTIONS_H__
 #define __SECTIONS_H__
 
+#include <optional>
 #include <stdint.h>
 #include "recomp.h"
 
@@ -43,6 +44,7 @@ typedef struct {
     RelocEntry* relocs;
     size_t num_relocs;
     size_t index;
+    std::optional<uint32_t> got_ram_addr;
 } SectionTableEntry;
 
 typedef struct {

--- a/librecomp/src/mods.cpp
+++ b/librecomp/src/mods.cpp
@@ -1867,8 +1867,8 @@ std::vector<recomp::mods::ModLoadErrorDetails> build_regen_list(
             }
             else {
                 section_ram_addr = recomp::overlays::get_section_ram_addr(section_index);
-                got_ram_addr = recomp::overlays::get_section_got_ram_addr(section_index);
                 cur_section_relocs = recomp::overlays::get_section_relocs(section_index);
+                got_ram_addr = recomp::overlays::get_section_got_ram_addr(section_index);
             }
 
             // Allocate a new section.

--- a/librecomp/src/mods.cpp
+++ b/librecomp/src/mods.cpp
@@ -1258,6 +1258,7 @@ struct RegeneratedSection {
     size_t first_func_index;
     size_t first_reloc_index;
     bool relocatable;
+    std::optional<uint32_t> got_ram_addr;
 };
 
 struct RegeneratedFunction {
@@ -1323,6 +1324,7 @@ N64Recomp::Context context_from_regenerated_list(const RegeneratedList& regenlis
         section_out.executable = true;
         section_out.relocatable = section_in.relocatable;
         section_out.has_mips32_relocs = false;
+        section_out.got_ram_addr = section_in.got_ram_addr;
 
         std::vector<size_t>& section_funcs_out = ret.section_functions[section_index];
         section_funcs_out.resize(cur_num_funcs);
@@ -1856,13 +1858,16 @@ std::vector<recomp::mods::ModLoadErrorDetails> build_regen_list(
 
             uint16_t section_index = find_section_it->second;
             uint32_t section_ram_addr;
+            std::optional<uint32_t> got_ram_addr;
 
             if constexpr (patched_regenlist) {
                 section_ram_addr = recomp::overlays::get_patch_section_ram_addr(section_index);
                 cur_section_relocs = recomp::overlays::get_patch_section_relocs(section_index);
+                got_ram_addr = std::nullopt;
             }
             else {
                 section_ram_addr = recomp::overlays::get_section_ram_addr(section_index);
+                got_ram_addr = recomp::overlays::get_section_got_ram_addr(section_index);
                 cur_section_relocs = recomp::overlays::get_section_relocs(section_index);
             }
 
@@ -1874,7 +1879,8 @@ std::vector<recomp::mods::ModLoadErrorDetails> build_regen_list(
                 .first_func_index = regenlist.functions.size(),
                 .first_reloc_index = regenlist.relocs.size(),
                 // Patch sections are never relocatable, so a section is relocatable if it has any relocs and is not a base patch section.
-                .relocatable = !patched_regenlist && !cur_section_relocs.empty()
+                .relocatable = !patched_regenlist && !cur_section_relocs.empty(),
+                .got_ram_addr = got_ram_addr
             });
 
             // Update the tracked section fields.

--- a/librecomp/src/overlays.cpp
+++ b/librecomp/src/overlays.cpp
@@ -137,6 +137,10 @@ uint32_t recomp::overlays::get_section_ram_addr(uint16_t code_section_index) {
     return sections_info.code_sections[code_section_index].ram_addr;
 }
 
+std::optional<uint32_t> recomp::overlays::get_section_got_ram_addr(uint16_t code_section_index) {
+    return sections_info.code_sections[code_section_index].got_ram_addr;
+}
+
 std::span<const RelocEntry> recomp::overlays::get_section_relocs(uint16_t code_section_index) {
     if (code_section_index < sections_info.num_code_sections) {
         const auto& section = sections_info.code_sections[code_section_index];


### PR DESCRIPTION
The other half of https://github.com/N64Recomp/N64Recomp/pull/187.

Passes the GOT address on to regenerated sections so the live recompiler can handle PIC jump tables.

Note: This PR includes changing the N64Recomp submodule ref, which I think might be a problem? Probably need to update that after the other PR is merged before merging this one.